### PR TITLE
Added function for 1D linear interpolation

### DIFF
--- a/lion/math/interpolate.hpp
+++ b/lion/math/interpolate.hpp
@@ -1,0 +1,75 @@
+#ifndef __INTERPOLATE__
+#define __INTERPOLATE__
+
+
+#include<vector>
+#include<iostream>
+#include<algorithm>
+#include<numeric>
+#include<stdexcept>
+
+using namespace std;
+
+template <typename T>
+class ITPObject{
+    vector<T> x,y;
+
+    std::vector<std::size_t> create_order(
+                            const std::vector<T>& vec)
+    {
+    std::vector<std::size_t> p(vec.size());
+    std::iota(p.begin(), p.end(), 0);
+    std::sort(p.begin(), p.end(),
+        [&](std::size_t i, std::size_t j){ return (vec[i] < vec[j]); });
+    return p;
+    }
+    
+    void apply_order(
+                std::vector<T>& vec,
+                const std::vector<std::size_t>& p)
+{
+    std::vector<bool> done(vec.size());
+    for (std::size_t i = 0; i < vec.size(); ++i)
+    {
+        if (done[i])
+        {
+            continue;
+        }
+        done[i] = true;
+        std::size_t prev_j = i;
+        std::size_t j = p[i];
+        while (i != j)
+        {
+            std::swap(vec[prev_j], vec[j]);
+            done[j] = true;
+            prev_j = j;
+            j = p[j];
+        }
+    }
+}
+
+public:
+    ITPObject() = default;
+    ITPObject(const vector<T>& x,const vector<T>& y){
+        
+        assert(x.size() == y.size());
+        this->x = x;
+        this->y = y;
+
+        auto p = create_order(x);
+        apply_order(this->x, p);
+        apply_order(this->y, p);
+    }
+
+    T interpolate(const T a) {
+        for(int i=0;i<this->x.size();i++){
+            if (a >= this->x[i] && a < this->x[i+1]){
+                return (this->y[i] + (this->y[i+1] - this->y[i])/(this->x[i+1] - this->x[i])*(a - this->x[i]));
+                break;
+            }
+        }
+        throw std::runtime_error("Parameter outside range");
+    }; 
+};
+
+#endif


### PR DESCRIPTION
I have added a class to interpolate using two vectors. It uses a linear interpolation in 1D for the time being but can later be extended to have spline etc. The main motivation behind introducing it is to add functionality to "fastest-lap" which allows engine curves(omega vs T to begin with) to be loaded.  I have tried using generic programming as much as possible, but there might be some improvements as I am still learning my way around c++ and generic programming.

It can be used as follows. 

```
#include "lion/math/interpolate.hpp"

int main(){
    
    vector<float> A({1,2,3,7,6,5,4,8}),B({1,4,9,49,36,25,16,64});

    ITPObject<float> C(A,B);

    float a(9);
    float value = C.interpolate(a);
    cout << "The value of "<< a << " interpolate is: " << value << endl;

    
    return 0;
}
```