### PR TITLE
Unused Attribute

### DIFF
--- a/lion/io/Xml_element.h
+++ b/lion/io/Xml_element.h
@@ -62,14 +62,33 @@ class Xml_element
     //! Add comment
     void add_comment(const std::string& text) { _e->InsertNewComment(text.c_str()); }
 
+    //! See if the element has children
+    bool has_children() const {return (_e->FirstChildElement() ? true : false);}
+
+    //! Get the first child
+    Xml_element get_first_child() const {return _e->FirstChildElement();}
+
     //! Get child by name
     Xml_element get_child(const std::string& name) const;
 
     //! See if a child exists
     bool has_child(const std::string& name) const;
 
+    //! See if parent exists
+    bool has_parent() const { return (_e->Parent()->ToElement() ? true : false); }
+
     //! Get parent
     Xml_element get_parent() const { return _e->Parent()->ToElement(); }
+
+    //! See if sibling exists
+    bool has_sibling() const { return (_e->NextSiblingElement() ? true : false); }
+
+    //! Get Next Sibling
+    Xml_element get_sibling() const { return _e->NextSiblingElement()->ToElement(); }
+
+    //! See if an attribute exists
+    //! @param[in] attribute: name of the attribute
+    bool has_attribute(const std::string& attribute) const {return (_e->FindAttribute(attribute.c_str()) ? true : false);}
 
     //! Get attribute by name
     //! @param[in] attribute: name of the attribute
@@ -80,11 +99,11 @@ class Xml_element
     //! @param[in] simply pass double() to overload this version
     double get_attribute(const std::string& attribute, double&&) const { return std::stod(_e->Attribute(attribute.c_str())); }
 
-    //! Set attribute
-    void add_attribute(const std::string& attrib_name, const std::string& attrib_value) { _e->SetAttribute(attrib_name.c_str(), attrib_value.c_str()); }
+    //! Sets a new attribute or modifies the value of an existing one
+    void set_attribute(const std::string& attrib_name, const std::string& attrib_value) { _e->SetAttribute(attrib_name.c_str(), attrib_value.c_str()); }
 
     template<typename T>
-    void add_attribute(const std::string& attrib_name, const T& attrib_value) { _e->SetAttribute(attrib_name.c_str(), attrib_value); }
+    void set_attribute(const std::string& attrib_name, const T& attrib_value) { _e->SetAttribute(attrib_name.c_str(), attrib_value); }
 
     //! Print
     void print(std::ostream& os) const;

--- a/lion/io/Xml_element.hpp
+++ b/lion/io/Xml_element.hpp
@@ -181,4 +181,5 @@ inline bool Xml_element::has_child(const std::string& name) const
         return child.has_child(the_rest);
 }
 
+
 #endif

--- a/test/io/data/example2.xml
+++ b/test/io/data/example2.xml
@@ -1,0 +1,21 @@
+<xml_doc>
+    <child1>
+        <double_parameter>3.14</double_parameter>
+        <child2>
+            <double_parameter>3.1415</double_parameter>
+            <child3>
+                <matrix3_parameter>1 2 3 4 5 6 7 8 9</matrix3_parameter>
+                <child4>
+                    <int_parameter>100</int_parameter>
+                </child4>
+            </child3>
+        </child2>
+    </child1>
+    <double_parameter>3.14</double_parameter>
+    <double_parameter_2>6.28</double_parameter_2>
+    <int_parameter>100</int_parameter>
+    <vector_parameter>1.0 3.0 5.0 
+                        5.0 6.0 -6 </vector_parameter>
+    <vector3_parameter>0.6 0.8 -1.0</vector3_parameter>
+    <matrix3_parameter>1 2 3 4 5 6 7 8 9</matrix3_parameter>
+</xml_doc>


### PR DESCRIPTION
# Feature Addition: Unused Attribute 

This feature is for supporting the [issue](https://github.com/juanmanzanero/fastest-lap/issues/21). It adds an attribute `__unused__`  to a parameter and all of it's parents iteratively, if the parameter has been read. 

- [x] Give as much detail as possible on what is included within the pull request
- [x] Make sure that new additions are not already present in the project
- [x] If it contains source code, comply with the [coding guidelines](https://github.com/juanmanzanero/lion-cpp/blob/main/CONTRIBUTING.md)
- [x] Add new tests for new features
- [x] Run and pass the tests using GitHub's workflows